### PR TITLE
add tests for recycler adapter

### DIFF
--- a/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/adapter/BaseRecyclerViewAdapter.kt
+++ b/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/adapter/BaseRecyclerViewAdapter.kt
@@ -5,17 +5,16 @@ import android.view.View
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import se.springworks.mvvmcomponents.recyclerview.holder.ItemViewHolder
-import se.springworks.mvvmcomponents.recyclerview.viewmodel.ItemViewModel
 
-abstract class BaseRecyclerViewAdapter<Model : Any, ViewModel : ItemViewModel<Model>>
-(private val items: MutableList<Model> = mutableListOf()) : RecyclerView.Adapter<ItemViewHolder<Model, ViewModel, *>>() {
+abstract class BaseRecyclerViewAdapter<Model : Any>
+(private val items: MutableList<Model> = mutableListOf()) : RecyclerView.Adapter<ItemViewHolder<Model>>() {
 
   private val itemClickSubject = PublishSubject.create<Model>()
   protected var observeClicks = true
 
   private lateinit var attachListener: View.OnAttachStateChangeListener
 
-  override fun onBindViewHolder(holder: ItemViewHolder<Model, ViewModel, *>, position: Int) {
+  override fun onBindViewHolder(holder: ItemViewHolder<Model>, position: Int) {
     val item = items[position]
     holder.bindTo(item, position)
   }
@@ -41,18 +40,18 @@ abstract class BaseRecyclerViewAdapter<Model : Any, ViewModel : ItemViewModel<Mo
   private fun initializeViewHolders(recyclerView: RecyclerView) {
     (0..itemCount)
         .mapNotNull { recyclerView.findViewHolderForAdapterPosition(it) }
-        .filterIsInstance<ItemViewHolder<*, *, *>>()
+        .filterIsInstance<ItemViewHolder<Model>>()
         .forEach { it.init() }
   }
 
   private fun releaseViewHolders(recyclerView: RecyclerView) {
     (0..itemCount)
         .mapNotNull { recyclerView.findViewHolderForAdapterPosition(it) }
-        .filterIsInstance<ItemViewHolder<*, *, *>>()
+        .filterIsInstance<ItemViewHolder<Model>>()
         .forEach { it.release() }
   }
 
-  override fun onViewAttachedToWindow(holder: ItemViewHolder<Model, ViewModel, *>) {
+  override fun onViewAttachedToWindow(holder: ItemViewHolder<Model>) {
     super.onViewAttachedToWindow(holder)
     holder.init()
     if (observeClicks) {
@@ -65,7 +64,7 @@ abstract class BaseRecyclerViewAdapter<Model : Any, ViewModel : ItemViewModel<Mo
     }
   }
 
-  override fun onViewDetachedFromWindow(holder: ItemViewHolder<Model, ViewModel, *>) {
+  override fun onViewDetachedFromWindow(holder: ItemViewHolder<Model>) {
     super.onViewDetachedFromWindow(holder)
     if (observeClicks) {
       holder.itemView.setOnClickListener(null)

--- a/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/adapter/StringRecyclerViewAdapter.kt
+++ b/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/adapter/StringRecyclerViewAdapter.kt
@@ -6,11 +6,11 @@ import com.vhudnitsky.mvvmcomponents.databinding.StringItemBinding
 import se.springworks.mvvmcomponents.recyclerview.holder.ItemViewHolder
 import se.springworks.mvvmcomponents.recyclerview.viewmodel.StringItemViewModel
 
-class StringRecyclerViewAdapter(items: List<String>) : BaseRecyclerViewAdapter<String, StringItemViewModel>(items.toMutableList()) {
+class StringRecyclerViewAdapter(items: List<String>) : BaseRecyclerViewAdapter<String>(items.toMutableList()) {
 
-  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder<String, StringItemViewModel, *> =
-      ItemViewHolder<String, StringItemViewModel, StringItemBinding>(parent,
-                                                                     LayoutInflater.from(parent.context),
-                                                                     StringItemBinding::inflate,
-                                                                     StringItemViewModel())
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder<String>
+      = ItemViewHolder<String>(parent,
+                               LayoutInflater.from(parent.context),
+                               StringItemBinding::inflate,
+                               StringItemViewModel())
 }

--- a/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/holder/ItemViewHolder.kt
+++ b/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/holder/ItemViewHolder.kt
@@ -8,15 +8,15 @@ import se.springworks.mvvmcomponents.recyclerview.viewmodel.ItemViewModel
 
 typealias BindingInflateFunction<DataBinding> = (inflater: LayoutInflater, root: ViewGroup, attachToRoot: Boolean) -> DataBinding
 
-open class BaseItemViewHolder<out DataBinding : ViewDataBinding>
-(val binding: DataBinding) : RecyclerView.ViewHolder(binding.root)
+open class BaseItemViewHolder
+(val binding: ViewDataBinding) : RecyclerView.ViewHolder(binding.root)
 
-open class ItemViewHolder<in Model : Any, out ViewModel : ItemViewModel<Model>, out DataBinding : ViewDataBinding>(
+open class ItemViewHolder<in Model : Any>(
     parent: ViewGroup,
     layoutInflater: LayoutInflater,
-    bindingInflateFunction: BindingInflateFunction<DataBinding>,
-    private val viewModel: ViewModel)
-  : BaseItemViewHolder<DataBinding>(bindingInflateFunction.invoke(layoutInflater, parent, false)) {
+    bindingInflateFunction: BindingInflateFunction<ViewDataBinding>,
+    private val viewModel: ItemViewModel<Model>)
+  : BaseItemViewHolder(bindingInflateFunction.invoke(layoutInflater, parent, false)) {
 
   open fun init() {
     viewModel.initialize()

--- a/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/viewmodel/StringItemViewModel.kt
+++ b/mvvm-components/src/main/kotlin/se/springworks/mvvmcomponents/recyclerview/viewmodel/StringItemViewModel.kt
@@ -2,10 +2,10 @@ package se.springworks.mvvmcomponents.recyclerview.viewmodel
 
 import android.databinding.ObservableField
 
-class StringItemViewModel : ItemViewModel<String>() {
-    val value = ObservableField<String>()
+open class StringItemViewModel : ItemViewModel<String>() {
+  val value = ObservableField<String>()
 
-    override fun setItem(item: String, position: Int) {
-        value.set(item)
-    }
+  override fun setItem(item: String, position: Int) {
+    value.set(item)
+  }
 }

--- a/mvvm-components/src/test/kotlin/se/springworks/mvvmcomponents/recyclerview/holder/BaseItemViewHolderTest.kt
+++ b/mvvm-components/src/test/kotlin/se/springworks/mvvmcomponents/recyclerview/holder/BaseItemViewHolderTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 
 class BaseItemViewHolderTest {
 
-  private lateinit var viewHolder: BaseItemViewHolder<ViewDataBinding>
+  private lateinit var viewHolder: BaseItemViewHolder
 
   @Before
   fun setUp() {

--- a/mvvm-components/src/test/kotlin/se/springworks/mvvmcomponents/recyclerview/holder/ItemViewHolderTest.kt
+++ b/mvvm-components/src/test/kotlin/se/springworks/mvvmcomponents/recyclerview/holder/ItemViewHolderTest.kt
@@ -15,7 +15,7 @@ import se.springworks.mvvmcomponents.recyclerview.viewmodel.ItemViewModel
 
 class ItemViewHolderTest {
 
-  private lateinit var viewHolder: ItemViewHolder<Unit, ItemViewModel<Unit>, ViewDataBinding>
+  private lateinit var viewHolder: ItemViewHolder<Unit>
 
   private lateinit var viewModel: ItemViewModel<Unit>
   private lateinit var viewBinding: ViewDataBinding


### PR DESCRIPTION
during investigation of our other generic logic, i realized that we don't have to use `ViewModel` as a generic type inside adapter. Also for the same reason we don't have to use `ViewModel` and `ViewDataBinding` as a generic inside viewholder, because it doesn't care